### PR TITLE
Improving processor names and labels wrapping

### DIFF
--- a/src/app/Instance/BridgeOverview/BridgeOverview.tsx
+++ b/src/app/Instance/BridgeOverview/BridgeOverview.tsx
@@ -35,17 +35,17 @@ export const BridgeOverview = (): JSX.Element => {
   const handleProcessorList = useCallback((): void => {
     setProcessorList([
       {
-        name: " disk-space-cleanup",
+        name: "disk space cleanup",
         connectors: ["Ansible playbook", "AI/ML learning Azure Database"],
         status: ManagedResourceStatus.Ready,
       },
       {
-        name: " 870-du29c-9nc-w-1ik",
+        name: "confirmed order analysis",
         connectors: ["AI/ML learning Azure Database"],
         status: ManagedResourceStatus.Failed,
       },
       {
-        name: " wi-9nc-w-1ik-ygsds",
+        name: "invoices generation and fulfillment notification",
         connectors: ["Azure Bigdata serverless Sink"],
         status: ManagedResourceStatus.Failed,
       },

--- a/src/app/Instance/BridgeOverview/Components/OBDashboardTableView.css
+++ b/src/app/Instance/BridgeOverview/Components/OBDashboardTableView.css
@@ -1,0 +1,8 @@
+.OB-Dashboard__resource__truncated-string {
+  --pf-c-truncate--MinWidth: 0;
+  --pf-c-truncate__start--MinWidth: 0;
+}
+
+.OB-Dashboard__resource__labels {
+  padding: var(--pf-global--spacer--xs) 0;
+}

--- a/src/app/Instance/BridgeOverview/Components/OBDashboardTableView.tsx
+++ b/src/app/Instance/BridgeOverview/Components/OBDashboardTableView.tsx
@@ -6,6 +6,7 @@ import {
   Flex,
   FlexItem,
   Label,
+  LabelGroup,
   Split,
   SplitItem,
   Stack,
@@ -24,6 +25,7 @@ import {
 import { ManagedResourceStatus } from "@rhoas/smart-events-management-sdk";
 import React from "react";
 import { DemoData } from "../BridgeOverview";
+import "./OBDashboardTableView.css";
 
 interface OBDashboardTableViewProps {
   data: DemoData[];
@@ -51,7 +53,6 @@ export const OBDashboardTableView = (
           </SplitItem>
         </Split>
       </CardBody>
-
       <Divider />
       <TableComposable variant="compact">
         {data &&
@@ -61,13 +62,17 @@ export const OBDashboardTableView = (
                 <Td>
                   <Stack>
                     <StackItem>
-                      <Flex>
-                        <FlexItem style={{ flexBasis: "100px" }}>
+                      <Flex flexWrap={{ default: "nowrap" }}>
+                        <FlexItem>
                           <TextContent>
                             <Text component="h4">
                               <a href="#">
-                                {" "}
-                                <Truncate content={processor.name}></Truncate>
+                                <Truncate
+                                  content={processor.name}
+                                  className={
+                                    "OB-Dashboard__resource__truncated-string"
+                                  }
+                                />
                               </a>
                             </Text>
                           </TextContent>
@@ -83,12 +88,23 @@ export const OBDashboardTableView = (
                         </FlexItem>
                       </Flex>
                     </StackItem>
-
-                    {processor.connectors?.map((connector, rowIndex) => (
-                      <StackItem key={rowIndex} style={{ padding: "0.2rem" }}>
-                        <Label color="green">{connector}</Label>
-                      </StackItem>
-                    ))}
+                    <StackItem
+                      key={rowIndex}
+                      className={"OB-Dashboard__resource__labels"}
+                    >
+                      <LabelGroup>
+                        {processor.connectors?.map((connector, rowIndex) => (
+                          <Label key={rowIndex} color="green">
+                            <Truncate
+                              content={connector}
+                              className={
+                                "OB-Dashboard__resource__truncated-string"
+                              }
+                            />
+                          </Label>
+                        ))}
+                      </LabelGroup>
+                    </StackItem>
                   </Stack>
                 </Td>
                 <Td isActionCell>


### PR DESCRIPTION
Here's a list of changes:
- processors names now take all the horizontal space available. if there's isn't enough space, the name will progressively be truncated
- the status label will always be next to the name
- sinks labels will stay on the same row if there is enough horizontal space. then they will wrap on multiple lines and if there's not enough space they will be truncated progressively
- the processor table will not overflow the parent column anymore on lower resolutions

I mainly focused on the wrapping/truncating stuff. There could be other overall improvements we could add.